### PR TITLE
fix: Fixed unexpected IBO crashing and added asserts for all openGL calls

### DIFF
--- a/Fireworks Engine/Fireworks Core/Fireworks Core.vcxproj
+++ b/Fireworks Engine/Fireworks Core/Fireworks Core.vcxproj
@@ -91,6 +91,7 @@
     <ClInclude Include="src\maths\vec4.h" />
     <ClInclude Include="src\physics\rigidbody2d.h" />
     <ClInclude Include="src\utils\fileutils.h" />
+    <ClInclude Include="src\utils\glassert.h" />
     <ClInclude Include="src\utils\imageloader.h" />
     <ClInclude Include="src\utils\timer.h" />
     <ClInclude Include="src\utils\wavloader.h" />

--- a/Fireworks Engine/Fireworks Core/Fireworks Core.vcxproj.filters
+++ b/Fireworks Engine/Fireworks Core/Fireworks Core.vcxproj.filters
@@ -144,6 +144,9 @@
     <ClInclude Include="src\graphics\renderers\shotrenderer3d.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="src\utils\glassert.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\graphics\buffers\buffer.cpp">

--- a/Fireworks Engine/Fireworks Core/src/graphics/Window.cpp
+++ b/Fireworks Engine/Fireworks Core/src/graphics/Window.cpp
@@ -61,9 +61,9 @@ namespace fireworks { namespace graphics {
             return false;
         }
 
-        glEnable(GL_BLEND);
-        glEnable(GL_DEPTH_TEST);
-        glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+        GLCall(glEnable(GL_BLEND));
+        GLCall(glEnable(GL_DEPTH_TEST));
+        GLCall(glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA));
         return true;
     }
 
@@ -137,17 +137,18 @@ namespace fireworks { namespace graphics {
 
     void Window::clear() const
     {
-		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-        glClearColor(backgroundColor.x, backgroundColor.y, backgroundColor.z, backgroundColor.w);
+		GLCall(glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT));
+        GLCall(glClearColor(backgroundColor.x, backgroundColor.y, backgroundColor.z, backgroundColor.w));
     }
 
     void Window::update() const
     {
-        GLenum error = glGetError();
-        if(error != GL_NO_ERROR)
-        {
-            std::cout << "ERROR::OpenGL::" << error << std::endl;
-        }
+        // Replaced with GLCall assert macro
+        /*   GLenum error = glGetError();
+           if(error != GL_NO_ERROR)
+           {
+               std::cout << "ERROR::OpenGL::" << error << std::endl;
+           }*/
         glfwPollEvents();
         glfwSwapBuffers(m_Window);
     }
@@ -181,7 +182,7 @@ namespace fireworks { namespace graphics {
 
     void window_resize_callback(GLFWwindow* window, int width, int height)
     {
-        glViewport(0, 0, width, height);
+        GLCall(glViewport(0, 0, width, height));
         Window* wind = (Window *) glfwGetWindowUserPointer(window);
         wind->m_Width = width;
         wind->m_Height = height;

--- a/Fireworks Engine/Fireworks Core/src/graphics/Window.h
+++ b/Fireworks Engine/Fireworks Core/src/graphics/Window.h
@@ -10,6 +10,8 @@
 #include <GLFW/glfw3.h>
 #include "../maths/maths.h"
 
+#include "../utils/glassert.h"
+
 namespace fireworks { namespace graphics {
 
 #define MAX_KEYS     1024

--- a/Fireworks Engine/Fireworks Core/src/graphics/buffers/buffer.cpp
+++ b/Fireworks Engine/Fireworks Core/src/graphics/buffers/buffer.cpp
@@ -7,25 +7,25 @@ namespace fireworks { namespace graphics {
     Buffer::Buffer(GLfloat* data, GLsizei count, GLuint componentCount)
     : m_ComponentCount(componentCount)
     {
-        glGenBuffers(1, &m_BufferID);
-        glBindBuffer(GL_ARRAY_BUFFER, m_BufferID);
-        glBufferData(GL_ARRAY_BUFFER, count * sizeof(GLfloat), data, GL_STATIC_DRAW);
-        glBindBuffer(GL_ARRAY_BUFFER, 0);
+        GLCall(glGenBuffers(1, &m_BufferID));
+        GLCall(glBindBuffer(GL_ARRAY_BUFFER, m_BufferID));
+        GLCall(glBufferData(GL_ARRAY_BUFFER, count * sizeof(GLfloat), data, GL_STATIC_DRAW));
+        GLCall(glBindBuffer(GL_ARRAY_BUFFER, 0));
     }
 
     Buffer::~Buffer()
     {
-        glDeleteBuffers(1, &m_BufferID);
+        GLCall(glDeleteBuffers(1, &m_BufferID));
     }
 
     void Buffer::bind() const
     {
-        glBindBuffer(GL_ARRAY_BUFFER, m_BufferID);
+        GLCall(glBindBuffer(GL_ARRAY_BUFFER, m_BufferID));
     }
 
     void Buffer::unbind() const
     {
-        glBindBuffer(GL_ARRAY_BUFFER, 0);
+        GLCall(glBindBuffer(GL_ARRAY_BUFFER, 0));
     }
 
 } }

--- a/Fireworks Engine/Fireworks Core/src/graphics/buffers/buffer.h
+++ b/Fireworks Engine/Fireworks Core/src/graphics/buffers/buffer.h
@@ -4,6 +4,8 @@
 #define GLEW_STATIC
 #include <GL/glew.h>
 
+#include "../../utils/glassert.h"
+
 namespace fireworks { namespace graphics {
 
 	/// Creates Vertex Buffers.
@@ -26,7 +28,7 @@ namespace fireworks { namespace graphics {
 		/// Unbind the buffer
 		void unbind() const;
 
-		/// Gets the types of componets in the vertex data.
+		/// Gets the types of components in the vertex data.
 		inline GLuint getComponentCount() const { return m_ComponentCount; }
 	};
 } }

--- a/Fireworks Engine/Fireworks Core/src/graphics/buffers/framebuffer.cpp
+++ b/Fireworks Engine/Fireworks Core/src/graphics/buffers/framebuffer.cpp
@@ -3,41 +3,41 @@
 
 fireworks::graphics::FrameBuffer::FrameBuffer(int Width, int Height)
 {
-	glGenFramebuffers(1, &m_BufferID);
-	glBindFramebuffer(GL_FRAMEBUFFER, m_BufferID);
+	GLCall(glGenFramebuffers(1, &m_BufferID));
+	GLCall(glBindFramebuffer(GL_FRAMEBUFFER, m_BufferID));
 
-	glGenTextures(1, &m_RenderTexture);
-	glBindTexture(GL_TEXTURE_2D, m_RenderTexture);
-	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, Width, Height, 0, GL_RGB, GL_UNSIGNED_BYTE, NULL);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+	GLCall(glGenTextures(1, &m_RenderTexture));
+	GLCall(glBindTexture(GL_TEXTURE_2D, m_RenderTexture));
+	GLCall(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, Width, Height, 0, GL_RGB, GL_UNSIGNED_BYTE, NULL));
+	GLCall(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR));
+	GLCall(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR));
 
-	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_RenderTexture, 0);
+	GLCall(glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_RenderTexture, 0));
 
 	m_RBO = new RenderBuffer(Width, Height);
 
-	glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_RENDERBUFFER, m_RBO->m_BufferID);
+	GLCall(glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_RENDERBUFFER, m_RBO->m_BufferID));
 
 	if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)
 		std::cout << "ERROR::FRAMEBUFFER:: Framebuffer is not complete" << std::endl;
 
 
- 	glBindFramebuffer(GL_FRAMEBUFFER, 0);
+ 	GLCall(glBindFramebuffer(GL_FRAMEBUFFER, 0));
 }
 
 fireworks::graphics::FrameBuffer::~FrameBuffer()
 {
-	glDeleteFramebuffers(1, &m_BufferID);
+	GLCall(glDeleteFramebuffers(1, &m_BufferID));
 }
 
 void fireworks::graphics::FrameBuffer::bind() const
 {
-	glBindFramebuffer(GL_FRAMEBUFFER, m_BufferID);
+	GLCall(glBindFramebuffer(GL_FRAMEBUFFER, m_BufferID));
 	//glBindTexture(GL_TEXTURE_2D, m_RenderTexture);
 }
 
 void fireworks::graphics::FrameBuffer::unbind() const
 {
-	glBindFramebuffer(GL_FRAMEBUFFER, 0);
-	glBindTexture(GL_TEXTURE_2D, 0);
+	GLCall(glBindFramebuffer(GL_FRAMEBUFFER, 0));
+	GLCall(glBindTexture(GL_TEXTURE_2D, 0));
 }

--- a/Fireworks Engine/Fireworks Core/src/graphics/buffers/framebuffer.h
+++ b/Fireworks Engine/Fireworks Core/src/graphics/buffers/framebuffer.h
@@ -1,10 +1,11 @@
 #pragma once
 
-
 // GLEW
 #define GLEW_STATIC
 #include <GL/glew.h>
 #include "renderbuffer.h"
+
+#include "../../utils/glassert.h"
 
 namespace fireworks { namespace graphics {
 

--- a/Fireworks Engine/Fireworks Core/src/graphics/buffers/indexbuffer.cpp
+++ b/Fireworks Engine/Fireworks Core/src/graphics/buffers/indexbuffer.cpp
@@ -1,6 +1,5 @@
 #include "indexbuffer.h"
 
-
 namespace fireworks { namespace graphics {
 
 
@@ -8,25 +7,25 @@ namespace fireworks { namespace graphics {
     : m_Count(count)
     {
         // TODO!: Fix unexpected crashing (suspected reason: improper dereferencing of IndexBuffer pointer(s))
-        glGenBuffers(1, &m_BufferID);
-        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_BufferID);
-        glBufferData(GL_ELEMENT_ARRAY_BUFFER, count * sizeof(GLushort), data, GL_DYNAMIC_DRAW);
-        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+        GLCall(glGenBuffers(1, &m_BufferID));
+        GLCall(glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_BufferID));
+        GLCall(glBufferData(GL_ELEMENT_ARRAY_BUFFER, count * sizeof(GLushort), data, GL_STATIC_DRAW));
+        GLCall(glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0));
     }
 
     IndexBuffer::~IndexBuffer()
     {
-        glDeleteBuffers(1, &m_BufferID);
+        GLCall(glDeleteBuffers(1, &m_BufferID));
     }
 
     void IndexBuffer::bind() const
     {
-        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_BufferID);
+        GLCall(glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_BufferID));
     }
 
     void IndexBuffer::unbind() const
     {
-        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+        GLCall(glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0));
     }
 
 } }

--- a/Fireworks Engine/Fireworks Core/src/graphics/buffers/indexbuffer.h
+++ b/Fireworks Engine/Fireworks Core/src/graphics/buffers/indexbuffer.h
@@ -4,6 +4,8 @@
 #define GLEW_STATIC
 #include <GL/glew.h>
 
+#include "../../utils/glassert.h"
+
 namespace fireworks { namespace graphics {
 
 	///	Creates Index Buffers.
@@ -27,6 +29,7 @@ namespace fireworks { namespace graphics {
 
         /// Gets the indices count
         inline GLuint getCount() const { return m_Count; }
+        /// Gets the index buffer gl instance
         inline GLuint getBuffer() const { return m_BufferID; }
     };
 

--- a/Fireworks Engine/Fireworks Core/src/graphics/buffers/renderbuffer.cpp
+++ b/Fireworks Engine/Fireworks Core/src/graphics/buffers/renderbuffer.cpp
@@ -2,23 +2,23 @@
 
 fireworks::graphics::RenderBuffer::RenderBuffer(int Width, int Height)
 {
-	glGenRenderbuffers(1, &m_BufferID);
-	glBindRenderbuffer(GL_RENDERBUFFER, m_BufferID);
-	glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8, Width, Height);
-	glBindRenderbuffer(GL_RENDERBUFFER, 0);
+	GLCall(glGenRenderbuffers(1, &m_BufferID));
+	GLCall(glBindRenderbuffer(GL_RENDERBUFFER, m_BufferID));
+	GLCall(glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8, Width, Height));
+	GLCall(glBindRenderbuffer(GL_RENDERBUFFER, 0));
 }
 
 fireworks::graphics::RenderBuffer::~RenderBuffer()
 {
-	glDeleteRenderbuffers(1, &m_BufferID);
+	GLCall(glDeleteRenderbuffers(1, &m_BufferID));
 }
 
 void fireworks::graphics::RenderBuffer::bind() const
 {
-	glBindRenderbuffer(GL_RENDERBUFFER, m_BufferID);
+	GLCall(glBindRenderbuffer(GL_RENDERBUFFER, m_BufferID));
 }
 
 void fireworks::graphics::RenderBuffer::unbind() const
 {
-	glBindRenderbuffer(GL_RENDERBUFFER, 0);
+	GLCall(glBindRenderbuffer(GL_RENDERBUFFER, 0));
 }

--- a/Fireworks Engine/Fireworks Core/src/graphics/buffers/renderbuffer.h
+++ b/Fireworks Engine/Fireworks Core/src/graphics/buffers/renderbuffer.h
@@ -4,6 +4,8 @@
 #define GLEW_STATIC
 #include <GL/glew.h>
 
+#include "../../utils/glassert.h"
+
 namespace fireworks { namespace graphics {
 
 	/// Class to generate Render Buffers.

--- a/Fireworks Engine/Fireworks Core/src/graphics/buffers/vertexarray.cpp
+++ b/Fireworks Engine/Fireworks Core/src/graphics/buffers/vertexarray.cpp
@@ -4,7 +4,7 @@ namespace fireworks { namespace graphics {
 
     VertexArray::VertexArray()
     {
-        glGenVertexArrays(1, &m_ArrayID);
+        GLCall(glGenVertexArrays(1, &m_ArrayID));
     }
 
     VertexArray::~VertexArray()
@@ -12,7 +12,7 @@ namespace fireworks { namespace graphics {
         for(int i = 0; i < m_Buffers.size(); i++)
             delete m_Buffers[i];
 
-        glDeleteVertexArrays(1, &m_ArrayID);
+        GLCall(glDeleteVertexArrays(1, &m_ArrayID));
     }
 
     void VertexArray::addBuffer(Buffer* buffer, GLuint index)
@@ -20,8 +20,8 @@ namespace fireworks { namespace graphics {
         bind();
         buffer->bind();
 
-        glEnableVertexAttribArray(index);
-        glVertexAttribPointer(index, buffer->getComponentCount(), GL_FLOAT, GL_FALSE, 0, 0);
+        GLCall(glEnableVertexAttribArray(index));
+        GLCall(glVertexAttribPointer(index, buffer->getComponentCount(), GL_FLOAT, GL_FALSE, 0, 0));
 
         buffer->unbind();
         unbind();
@@ -31,12 +31,12 @@ namespace fireworks { namespace graphics {
 
     void VertexArray::bind() const
     {
-        glBindVertexArray(m_ArrayID);
+        GLCall(glBindVertexArray(m_ArrayID));
     }
 
     void VertexArray::unbind() const
     {
-        glBindVertexArray(0);
+        GLCall(glBindVertexArray(0));
     }
 
 } }

--- a/Fireworks Engine/Fireworks Core/src/graphics/buffers/vertexarray.h
+++ b/Fireworks Engine/Fireworks Core/src/graphics/buffers/vertexarray.h
@@ -6,6 +6,8 @@
 #include <GL/glew.h>
 #include "buffer.h"
 
+#include "../../utils/glassert.h"
+
 namespace fireworks { namespace graphics {
 
     /// Creates Vertex Array Object (VAOs).

--- a/Fireworks Engine/Fireworks Core/src/graphics/model.cpp
+++ b/Fireworks Engine/Fireworks Core/src/graphics/model.cpp
@@ -44,7 +44,6 @@ namespace fireworks { namespace graphics {
         this->m_Directory = path.substr(0, path.find_last_of('/')); // WTF! happened here?
         size_t lastindex = path.find_last_of(".");
         std::string rawname = path.substr(0, lastindex);
-        std::cout << "Path is : " << rawname << std::endl;
         m_Directory = rawname;
         m_RootMesh = this->processNode(scene->mRootNode, scene);
     }
@@ -68,7 +67,7 @@ namespace fireworks { namespace graphics {
             masterSubMesh.indices.insert(masterSubMesh.indices.begin(), subMeshes[i].indices.begin(), subMeshes[i].indices.end());
             masterSubMesh.material_textures.insert(masterSubMesh.material_textures.begin(), subMeshes[i].material_textures.begin(), subMeshes[i].material_textures.end());
         }
-        modelIBO = new IndexBuffer(&(masterSubMesh.indices[0]), masterSubMesh.indices.size() * sizeof(GLushort));
+        modelIBO = new IndexBuffer(&(masterSubMesh.indices[0]), masterSubMesh.indices.size());
         return Mesh(masterSubMesh.vertices, masterSubMesh.indices, masterSubMesh.material_textures, m_Transform, m_Shader);
     }
 
@@ -123,7 +122,7 @@ namespace fireworks { namespace graphics {
              * Diffuse  : texture_diffuseN
              * Specular : texture_specularN
              * Normal   : texture_normalN
-            */
+             */
 
             std::vector<Texture> diffuseMaps = this->loadMaterialTextures(material, aiTextureType_DIFFUSE, "texture_diffuse");
             submesh.material_textures.insert(submesh.material_textures.end(), diffuseMaps.begin(), diffuseMaps.end());

--- a/Fireworks Engine/Fireworks Core/src/graphics/renderables/label.cpp
+++ b/Fireworks Engine/Fireworks Core/src/graphics/renderables/label.cpp
@@ -13,8 +13,8 @@ namespace fireworks { namespace graphics {
 		m_FontShader->enable();
 		maths::mat4 projection = maths::mat4::orthographic(0.0f, 800.0f, 0.0f, 600.0f, -1.0f, 1.0f);
 		glUniformMatrix4fv(glGetUniformLocation(m_FontShader->getShaderProgram(), "projection"), 1, GL_FALSE, projection.elements);
-		glEnable(GL_BLEND);
-		glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+		GLCall(glEnable(GL_BLEND));
+		GLCall(glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA));
 	}
 
 	// TODO: Batch the draw calls
@@ -24,9 +24,9 @@ namespace fireworks { namespace graphics {
 		float y = position.y;
 		float scale = 1.0f;
 		m_FontShader->enable();
-		glUniform3f(glGetUniformLocation(m_FontShader->getShaderProgram(), "textColor"), color.x, color.y, color.z);
-		glActiveTexture(GL_TEXTURE0);
-		glBindVertexArray(m_VAO);
+		GLCall(glUniform3f(glGetUniformLocation(m_FontShader->getShaderProgram(), "textColor"), color.x, color.y, color.z));
+		GLCall(glActiveTexture(GL_TEXTURE0));
+		GLCall(glBindVertexArray(m_VAO));
 
 		std::string::const_iterator c;
 		for (c = text.begin(); c != text.end(); c++)
@@ -47,15 +47,15 @@ namespace fireworks { namespace graphics {
 				{ xpos + w, ypos,       1.0f, 1.0f },
 				{ xpos + w, ypos + h,   1.0f, 0.0f }
 			};
-			glBindTexture(GL_TEXTURE_2D, ch.TextureID);
-			glBindBuffer(GL_ARRAY_BUFFER, m_VBO);
-			glBufferSubData(GL_ARRAY_BUFFER, 0, sizeof(vertices), vertices);
-			glBindBuffer(GL_ARRAY_BUFFER, 0);
-			glDrawArrays(GL_TRIANGLES, 0, 6);
+			GLCall(glBindTexture(GL_TEXTURE_2D, ch.TextureID));
+			GLCall(glBindBuffer(GL_ARRAY_BUFFER, m_VBO));
+			GLCall(glBufferSubData(GL_ARRAY_BUFFER, 0, sizeof(vertices), vertices));
+			GLCall(glBindBuffer(GL_ARRAY_BUFFER, 0));
+			GLCall(glDrawArrays(GL_TRIANGLES, 0, 6));
 			x += (ch.Advance >> 6) * scale; // bit shift by 6 to get value in pixels (2^6 = 64)
 		}
-		glBindVertexArray(0);
-		glBindTexture(GL_TEXTURE_2D, 0);
+		GLCall(glBindVertexArray(0));
+		GLCall(glBindTexture(GL_TEXTURE_2D, 0));
 	}
 
 	void Label::load()
@@ -75,7 +75,7 @@ namespace fireworks { namespace graphics {
 
 		FT_Set_Pixel_Sizes(face, 0, font.fontSize);
 
-		glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+		GLCall(glPixelStorei(GL_UNPACK_ALIGNMENT, 1));
 
 		for (unsigned char c = 0; c < 128; c++)
 		{
@@ -86,14 +86,14 @@ namespace fireworks { namespace graphics {
 			}
 
 			unsigned int font_texture;
-			glGenTextures(1, &font_texture);
-			glBindTexture(GL_TEXTURE_2D, font_texture);
-			glTexImage2D(GL_TEXTURE_2D, 0, GL_RED, face->glyph->bitmap.width, face->glyph->bitmap.rows, 0, GL_RED, GL_UNSIGNED_BYTE, face->glyph->bitmap.buffer);
+			GLCall(glGenTextures(1, &font_texture));
+			GLCall(glBindTexture(GL_TEXTURE_2D, font_texture));
+			GLCall(glTexImage2D(GL_TEXTURE_2D, 0, GL_RED, face->glyph->bitmap.width, face->glyph->bitmap.rows, 0, GL_RED, GL_UNSIGNED_BYTE, face->glyph->bitmap.buffer));
 
-			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+			GLCall(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE));
+			GLCall(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
+			GLCall(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR));
+			GLCall(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR));
 
 			Character character = {
 				font_texture,
@@ -108,15 +108,15 @@ namespace fireworks { namespace graphics {
 		FT_Done_Face(face);
 		FT_Done_FreeType(ft);
 
-		glGenVertexArrays(1, &m_VAO);
-		glGenBuffers(1, &m_VBO);
-		glBindVertexArray(m_VAO);
-		glBindBuffer(GL_ARRAY_BUFFER, m_VBO);
-		glBufferData(GL_ARRAY_BUFFER, sizeof(float) * 6 * 4, NULL, GL_DYNAMIC_DRAW);
-		glEnableVertexAttribArray(0);
-		glVertexAttribPointer(0, 4, GL_FLOAT, GL_FALSE, 4 * sizeof(float), 0);
-		glBindBuffer(GL_ARRAY_BUFFER, 0);
-		glBindVertexArray(0);
+        GLCall(glGenVertexArrays(1, &m_VAO));
+        GLCall(glGenBuffers(1, &m_VBO));
+        GLCall(glBindVertexArray(m_VAO));
+        GLCall(glBindBuffer(GL_ARRAY_BUFFER, m_VBO));
+        GLCall(glBufferData(GL_ARRAY_BUFFER, sizeof(float) * 6 * 4, NULL, GL_DYNAMIC_DRAW));
+        GLCall(glEnableVertexAttribArray(0));
+        GLCall(glVertexAttribPointer(0, 4, GL_FLOAT, GL_FALSE, 4 * sizeof(float), 0));
+        GLCall(glBindBuffer(GL_ARRAY_BUFFER, 0));
+        GLCall(glBindVertexArray(0));
 	}
 
 } }

--- a/Fireworks Engine/Fireworks Core/src/graphics/renderables/label.h
+++ b/Fireworks Engine/Fireworks Core/src/graphics/renderables/label.h
@@ -8,6 +8,8 @@
 
 #include "renderable2d.h"
 
+#include "../../utils/glassert.h"
+
 namespace fireworks { namespace graphics {
 
 	struct Character

--- a/Fireworks Engine/Fireworks Core/src/graphics/renderers/batchrenderer2d.cpp
+++ b/Fireworks Engine/Fireworks Core/src/graphics/renderers/batchrenderer2d.cpp
@@ -23,36 +23,26 @@ namespace fireworks { namespace graphics {
     {
         delete m_IBO;
         glDeleteBuffers(1, &m_VBO);
-        // TODO: Delete all the textures here (IDK if this works)
-        //const int textures_size = m_TextureSlots.size();
-        //GLuint textures[textures_size];
-        //for(int i = 0; i < textures_size; i++)
-        //{
-        //    textures[i] = m_TextureSlots[i];
-        //}
-        //glDeleteTextures(textures_size, textures);
-
-        // Deleting text
-        // gltDeleteText(m_Text);
+        glDeleteTextures(m_TextureSlots.size(), &(m_TextureSlots)[0]);
     }
 
     void BatchRenderer2D::init()
     {
-        glGenVertexArrays(1, &m_VAO);
-        glGenBuffers(1, &m_VBO);
+        GLCall(glGenVertexArrays(1, &m_VAO));
+        GLCall(glGenBuffers(1, &m_VBO));
 
-        glBindVertexArray(m_VAO);
-        glBindBuffer(GL_ARRAY_BUFFER, m_VBO);
-        glBufferData(GL_ARRAY_BUFFER, RENDERER_BUFFER_SIZE, NULL, GL_DYNAMIC_DRAW);
-        glEnableVertexAttribArray(SHADER_VERTEX_INDEX);
-        glEnableVertexAttribArray(SHADER_UV_INDEX);
-        glEnableVertexAttribArray(SHADER_TID_INDEX);
-        glEnableVertexAttribArray(SHADER_COLOR_INDEX);
-        glVertexAttribPointer(SHADER_VERTEX_INDEX,  3, GL_FLOAT, GL_FALSE, RENDERER_VERTEX_SIZE, (const GLvoid*)0);
-        glVertexAttribPointer(SHADER_UV_INDEX,      2, GL_FLOAT, GL_FALSE, RENDERER_VERTEX_SIZE, (const GLvoid*)(3 * sizeof(GLfloat)));
-        glVertexAttribPointer(SHADER_TID_INDEX,     1, GL_FLOAT, GL_FALSE, RENDERER_VERTEX_SIZE, (const GLvoid*)(5 * sizeof(GLfloat)));
-        glVertexAttribPointer(SHADER_COLOR_INDEX,   4, GL_FLOAT, GL_FALSE, RENDERER_VERTEX_SIZE, (const GLvoid*)(6 * sizeof(GLfloat)));
-        glBindBuffer(GL_ARRAY_BUFFER, 0);
+        GLCall(glBindVertexArray(m_VAO));
+        GLCall(glBindBuffer(GL_ARRAY_BUFFER, m_VBO));
+        GLCall(glBufferData(GL_ARRAY_BUFFER, RENDERER_BUFFER_SIZE, NULL, GL_DYNAMIC_DRAW));
+        GLCall(glEnableVertexAttribArray(SHADER_VERTEX_INDEX));
+        GLCall(glEnableVertexAttribArray(SHADER_UV_INDEX));
+        GLCall(glEnableVertexAttribArray(SHADER_TID_INDEX));
+        GLCall(glEnableVertexAttribArray(SHADER_COLOR_INDEX));
+        GLCall(glVertexAttribPointer(SHADER_VERTEX_INDEX,  3, GL_FLOAT, GL_FALSE, RENDERER_VERTEX_SIZE, (const GLvoid*)0));
+        GLCall(glVertexAttribPointer(SHADER_UV_INDEX,      2, GL_FLOAT, GL_FALSE, RENDERER_VERTEX_SIZE, (const GLvoid*)(3 * sizeof(GLfloat))));
+        GLCall(glVertexAttribPointer(SHADER_TID_INDEX,     1, GL_FLOAT, GL_FALSE, RENDERER_VERTEX_SIZE, (const GLvoid*)(5 * sizeof(GLfloat))));
+        GLCall(glVertexAttribPointer(SHADER_COLOR_INDEX,   4, GL_FLOAT, GL_FALSE, RENDERER_VERTEX_SIZE, (const GLvoid*)(6 * sizeof(GLfloat))));
+        GLCall(glBindBuffer(GL_ARRAY_BUFFER, 0));
 
         int offset = 0;
         for(int i = 0; i < RENDERER_INDICES_SIZE; i += 6)
@@ -68,30 +58,14 @@ namespace fireworks { namespace graphics {
             offset += 4; // because each sprite has 4 indices and 6 vertices
         }
 
-		//for (int i = 0; i < RENDERER_INDICES_SIZE; i += 3)
-		//{
-		//	tris_indices[i] = offset + 0;
-		//	tris_indices[i + 1] = offset + 1;
-		//	tris_indices[i + 2] = offset + 2;
-
-		//	offset += 3; // because each tris has 3 indices and 3 vertices
-		//}
-
         m_IBO = new IndexBuffer(quad_indices, RENDERER_INDICES_SIZE);
-		//m_TIBO = new IndexBuffer(tris_indices, RENDERER_INDICES_SIZE);
 
-        glBindVertexArray(0);
-
-        // Initialize glText
-        gltInit();
-
-        // Creating text
-        m_Text = gltCreateText();
+        GLCall(glBindVertexArray(0));
     }
 
     void BatchRenderer2D::begin()
     {
-        glBindBuffer(GL_ARRAY_BUFFER, m_VBO);
+        GLCall(glBindBuffer(GL_ARRAY_BUFFER, m_VBO));
         m_Buffer = (VertexData*)glMapBuffer(GL_ARRAY_BUFFER, GL_WRITE_ONLY);
     }
 
@@ -140,6 +114,7 @@ namespace fireworks { namespace graphics {
         }
         else
         {
+            // TODO: use hex for vertex colors
             // int r = color.x * 255.0f;
             // int g = color.y * 255.0f;
             // int b = color.z * 255.0f;
@@ -179,33 +154,13 @@ namespace fireworks { namespace graphics {
 		else if (primitive == Primitive2D::Triangle)
 		{
             std::cerr << "ERROR::BATCH_RENDERER_2D::Batch Renderer 2D does not support triangle primitive" << std::endl;
-
-			//m_Buffer->vertex = *m_TransformationBack * position;
-			//m_Buffer->uv = uv[0];
-			//m_Buffer->tid = ts;
-			//m_Buffer->color = color;
-			//m_Buffer++;
-
-			//m_Buffer->vertex = *m_TransformationBack * maths::vec3(position.x + (size.x / 2.0f), position.y + size.y, position.z);
-			//m_Buffer->uv = uv[1];
-			//m_Buffer->tid = ts;
-			//m_Buffer->color = color;
-			//m_Buffer++;
-
-			//m_Buffer->vertex = *m_TransformationBack * maths::vec3(position.x + size.x, position.y, position.z);
-			//m_Buffer->uv = uv[2];
-			//m_Buffer->tid = ts;
-			//m_Buffer->color = color;
-			//m_Buffer++;
-
-			//m_IndicesCount += 3;
 		}
     }
 
     void BatchRenderer2D::end()
     {
-        glUnmapBuffer(GL_ARRAY_BUFFER);
-        glBindBuffer(GL_ARRAY_BUFFER, 0);
+        GLCall(glUnmapBuffer(GL_ARRAY_BUFFER));
+        GLCall(glBindBuffer(GL_ARRAY_BUFFER, 0));
     }
 
     void BatchRenderer2D::flush()
@@ -214,16 +169,16 @@ namespace fireworks { namespace graphics {
         m_Shader->setUniformMat4("view", m_Camera2D->getViewMatrix());
         for(int i = 0; i < m_TextureSlots.size(); i++)
         {
-            glActiveTexture(GL_TEXTURE0 + i);
-            glBindTexture(GL_TEXTURE_2D, m_TextureSlots[i]);
+            GLCall(glActiveTexture(GL_TEXTURE0 + i));
+            GLCall(glBindTexture(GL_TEXTURE_2D, m_TextureSlots[i]));
         }
-        glBindVertexArray(m_VAO);
+        GLCall(glBindVertexArray(m_VAO));
         m_IBO->bind();
 
-        glDrawElements(GL_TRIANGLES, m_IndicesCount, GL_UNSIGNED_SHORT, NULL);
+        GLCall(glDrawElements(GL_TRIANGLES, m_IndicesCount, GL_UNSIGNED_SHORT, NULL));
 
         m_IBO->unbind();
-        glBindVertexArray(0);
+        GLCall(glBindVertexArray(0));
 
         m_IndicesCount = 0;
         m_TextureSlots.clear();

--- a/Fireworks Engine/Fireworks Core/src/graphics/renderers/batchrenderer2d.h
+++ b/Fireworks Engine/Fireworks Core/src/graphics/renderers/batchrenderer2d.h
@@ -5,9 +5,7 @@
 #include "../renderables/renderable2d.h"
 #include "renderer2d.h"
 
-// #include <FTGL/ftgl.h>
-#define GLT_IMPLEMENTATION
-#include "../../../ext/gltext.h"
+#include "../../utils/glassert.h"
 
 namespace fireworks { namespace graphics {
 
@@ -28,14 +26,9 @@ namespace fireworks { namespace graphics {
         GLuint                  m_VBO;
         VertexData*             m_Buffer;
 		IndexBuffer*            m_IBO;
-		//IndexBuffer* m_TIBO;
         GLsizei                 m_IndicesCount;
         std::vector<GLuint>     m_TextureSlots;
-
-		GLushort quad_indices[RENDERER_INDICES_SIZE];
-		//GLushort tris_indices[RENDERER_INDICES_SIZE];
-
-        GLTtext*                m_Text;
+		GLushort                quad_indices[RENDERER_INDICES_SIZE];
     public:
         /// Creates the batch renderer 
         /// 

--- a/Fireworks Engine/Fireworks Core/src/utils/glassert.h
+++ b/Fireworks Engine/Fireworks Core/src/utils/glassert.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <iostream>
+
+// GLEW
+#define GLEW_STATIC
+#include <GL/glew.h>
+
+namespace fireworks {
+
+    //#ifdef ((_WIN32) || (_WIN64)) // This OS Macro isn't working why?
+    #define ASSERT(x) if (!(x)) __debugbreak(); // Break the debugger from executing 
+    #define GLCall(x)   GLClearError();\
+                        (x);\
+                        ASSERT(GLLogCall(#x, __FILE__, __LINE__))
+    //#endif
+            
+    static void GLClearError()
+    {
+        while (glGetError() != GL_NO_ERROR);
+    }
+
+    static bool GLLogCall(const char* functionName, const char* file, int line)
+    {
+        while (GLenum error = glGetError())
+        {
+            std::cerr << "OpenGL::ERROR:: " << error << "[Function : " << functionName << ", File : " << file << ", at Line : " << line << "]" << std::endl;
+            return false;
+        }
+        return true;
+    }
+}

--- a/Fireworks Engine/Sandbox/imgui.ini
+++ b/Fireworks Engine/Sandbox/imgui.ini
@@ -1,15 +1,15 @@
 [Window][DockSpace Demo]
-Size=800,600
+Size=800,503
 Collapsed=0
 
 [Window][Debug##Default]
-Pos=60,60
-Size=400,400
+Pos=-125,285
+Size=543,699
 Collapsed=0
 
 [Window][Dear ImGui Demo]
-Pos=224,364
-Size=800,581
+Pos=307,93
+Size=456,367
 Collapsed=0
 
 [Window][Example: Custom rendering]
@@ -43,8 +43,8 @@ Size=600,400
 Collapsed=0
 
 [Window][Stats]
-Pos=896,220
-Size=304,123
+Pos=984,165
+Size=456,336
 Collapsed=0
 
 [Window][Example: Log]

--- a/Fireworks Engine/Sandbox/test/EditorGUI.h
+++ b/Fireworks Engine/Sandbox/test/EditorGUI.h
@@ -21,6 +21,7 @@ public:
 		IMGUI_CHECKVERSION();
 		ImGui::CreateContext();
 		ImGuiIO& io = ImGui::GetIO(); (void)io;
+		//io.ConfigFlags |= ImGuiConfigFlags_ViewportsEnable;
 		ImGui::StyleColorsDark();
 	}
 
@@ -44,6 +45,8 @@ public:
 		ImGui_ImplGlfw_NewFrame();
 		ImGui::NewFrame();
 
+		//ImGui::ShowDemoWindow(nullptr);
+
 		if(enableDocking)
 			ImGuiEnableDocking(&enableDocking);
 		
@@ -51,6 +54,9 @@ public:
 
 		ImGui::Render();
 		ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
+		// Multi-view port rendering is not working
+        //ImGui::UpdatePlatformWindows();
+        //ImGui::RenderPlatformWindowsDefault();
 	}
 	virtual void RenderGUI() = 0;
 private:

--- a/Fireworks Engine/Sandbox/test/scene3DTest.h
+++ b/Fireworks Engine/Sandbox/test/scene3DTest.h
@@ -1,8 +1,9 @@
 #include <fireworks.h>
+#include "EditorGUI.h"
 
 using namespace fireworks;
 
-class Scene3DTest : public Fireworks
+class Scene3DTest : public Fireworks, public EditorGUI
 {
 private:
     Window* window;
@@ -15,9 +16,10 @@ private:
     bool firstMouse = true;
     double lastX = 400.0, lastY = 300.0;
 public:
-    Scene3DTest()
+    Scene3DTest() : EditorGUI()
     {
-        window = createWindow("3D Scene Testing", 800, 600);
+        window = createWindow("3D Scene Testing", 1600, 1200);
+        InitGUI(window);
         camera3D = new FreeFlyCamera(vec3(0, 0, -5));
         meshShader = new Shader(".\\shaders\\mesh.vert", ".\\shaders\\mesh.frag");
         ShotRenderer3D* shot3d = new ShotRenderer3D(camera3D);
@@ -79,6 +81,16 @@ public:
 
     }
 
+    void RenderGUI()
+    {
+        ImGui::Begin("Stats");
+        {
+            ImGui::Text("FPS : %d", getFPS());
+            ImGui::Text("Camera Positions : [%2.2f, %2.2f, %2.2f]", camera3D->position.x, camera3D->position.y, camera3D->position.z);
+        }
+        ImGui::End();
+    }
+
     // Runs as fast as possible
     void render() override
     {
@@ -107,7 +119,7 @@ public:
         else if (window->isKeyHeld(Keys::LEFT))
             camera3D->processKeyboardMovement(FreeFlyCameraMoveDirection::YAW_LEFT, deltaTime);
  
-
         scene->render();
+        InitRenderingGUI();
     }
 };


### PR DESCRIPTION
[Hypothesis 1 (**Unsolved**)] : Generated the Index buffer aka ELEMENT_ARRAY_BUFFER using GL_DYNAMIC_DRAW, instead it should be generated using GL_STATIC_DRAW, because index buffer objects cannot be changed dynamically, hence using that configurations state resulted in unexpected writing behavior by OpenGL. OFC, this is also a mistake.

[Hypothesis 2 (**Solved**)] : Mistakenly passed the count of the indices size  multiplied by the data size i.e sizeof(GLushort) to instantiate IndexBuffer using the constructor instead just passing the count, because it is done so implicitly in the constructor.